### PR TITLE
Several fixes

### DIFF
--- a/Batch WAV to OGG Converter/frmMain.Designer.cs
+++ b/Batch WAV to OGG Converter/frmMain.Designer.cs
@@ -28,269 +28,271 @@
         /// </summary>
         private void InitializeComponent()
         {
-			this.group_step1 = new System.Windows.Forms.GroupBox();
-			this.label1 = new System.Windows.Forms.Label();
-			this.label2 = new System.Windows.Forms.Label();
-			this.txtSource = new System.Windows.Forms.TextBox();
-			this.btnChooseSource = new System.Windows.Forms.Button();
-			this.group_step4 = new System.Windows.Forms.GroupBox();
-			this.btnCancel = new System.Windows.Forms.Button();
-			this.lblStatus = new System.Windows.Forms.Label();
-			this.convertProgress = new System.Windows.Forms.ProgressBar();
-			this.label3 = new System.Windows.Forms.Label();
-			this.btnConvert = new System.Windows.Forms.Button();
-			this.group_step2 = new System.Windows.Forms.GroupBox();
-			this.label4 = new System.Windows.Forms.Label();
-			this.target_label = new System.Windows.Forms.Label();
-			this.txtTarget = new System.Windows.Forms.TextBox();
-			this.btnChooseTarget = new System.Windows.Forms.Button();
-			this.group_step3 = new System.Windows.Forms.GroupBox();
-			this.boolOverride = new System.Windows.Forms.CheckBox();
-			this.boolRecursive = new System.Windows.Forms.CheckBox();
-			this.boolDelete = new System.Windows.Forms.CheckBox();
-			this.label6 = new System.Windows.Forms.Label();
-			this.group_step1.SuspendLayout();
-			this.group_step4.SuspendLayout();
-			this.group_step2.SuspendLayout();
-			this.group_step3.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// group_step1
-			// 
-			this.group_step1.Controls.Add(this.label1);
-			this.group_step1.Controls.Add(this.label2);
-			this.group_step1.Controls.Add(this.txtSource);
-			this.group_step1.Controls.Add(this.btnChooseSource);
-			this.group_step1.Location = new System.Drawing.Point(5, 2);
-			this.group_step1.Name = "group_step1";
-			this.group_step1.Size = new System.Drawing.Size(380, 67);
-			this.group_step1.TabIndex = 5;
-			this.group_step1.TabStop = false;
-			this.group_step1.Text = "Step 1";
-			// 
-			// label1
-			// 
-			this.label1.Location = new System.Drawing.Point(6, 16);
-			this.label1.Name = "label1";
-			this.label1.Size = new System.Drawing.Size(293, 16);
-			this.label1.TabIndex = 1;
-			this.label1.Text = "Select the target folder to read the wav files";
-			this.label1.Click += new System.EventHandler(this.label1_Click);
-			// 
-			// label2
-			// 
-			this.label2.AutoSize = true;
-			this.label2.Location = new System.Drawing.Point(7, 38);
-			this.label2.Name = "label2";
-			this.label2.Size = new System.Drawing.Size(44, 13);
-			this.label2.TabIndex = 3;
-			this.label2.Text = "Source:";
-			// 
-			// txtSource
-			// 
-			this.txtSource.Location = new System.Drawing.Point(57, 35);
-			this.txtSource.Name = "txtSource";
-			this.txtSource.Size = new System.Drawing.Size(242, 20);
-			this.txtSource.TabIndex = 0;
-			this.txtSource.TextChanged += new System.EventHandler(this.txtSource_TextChanged);
-			// 
-			// btnChooseSource
-			// 
-			this.btnChooseSource.Location = new System.Drawing.Point(305, 33);
-			this.btnChooseSource.Name = "btnChooseSource";
-			this.btnChooseSource.Size = new System.Drawing.Size(69, 23);
-			this.btnChooseSource.TabIndex = 2;
-			this.btnChooseSource.Text = "Browse";
-			this.btnChooseSource.UseVisualStyleBackColor = true;
-			this.btnChooseSource.Click += new System.EventHandler(this.btnChooseSource_Click);
-			// 
-			// group_step4
-			// 
-			this.group_step4.Controls.Add(this.btnCancel);
-			this.group_step4.Controls.Add(this.lblStatus);
-			this.group_step4.Controls.Add(this.convertProgress);
-			this.group_step4.Controls.Add(this.label3);
-			this.group_step4.Controls.Add(this.btnConvert);
-			this.group_step4.Location = new System.Drawing.Point(5, 234);
-			this.group_step4.Name = "group_step4";
-			this.group_step4.Size = new System.Drawing.Size(380, 83);
-			this.group_step4.TabIndex = 6;
-			this.group_step4.TabStop = false;
-			this.group_step4.Text = "Step 4";
-			this.group_step4.Visible = false;
-			// 
-			// btnCancel
-			// 
-			this.btnCancel.Location = new System.Drawing.Point(305, 50);
-			this.btnCancel.Name = "btnCancel";
-			this.btnCancel.Size = new System.Drawing.Size(69, 23);
-			this.btnCancel.TabIndex = 5;
-			this.btnCancel.Text = "Cancel";
-			this.btnCancel.UseVisualStyleBackColor = true;
-			// 
-			// lblStatus
-			// 
-			this.lblStatus.AutoSize = true;
-			this.lblStatus.Location = new System.Drawing.Point(22, 55);
-			this.lblStatus.Name = "lblStatus";
-			this.lblStatus.Size = new System.Drawing.Size(50, 13);
-			this.lblStatus.TabIndex = 4;
-			this.lblStatus.Text = "STATUS";
-			this.lblStatus.Click += new System.EventHandler(this.label5_Click_1);
-			// 
-			// convertProgress
-			// 
-			this.convertProgress.Location = new System.Drawing.Point(6, 50);
-			this.convertProgress.Name = "convertProgress";
-			this.convertProgress.Size = new System.Drawing.Size(293, 23);
-			this.convertProgress.TabIndex = 3;
-			this.convertProgress.Visible = false;
-			// 
-			// label3
-			// 
-			this.label3.Location = new System.Drawing.Point(6, 16);
-			this.label3.Name = "label3";
-			this.label3.Size = new System.Drawing.Size(368, 31);
-			this.label3.TabIndex = 1;
-			this.label3.Text = "Click the button below to begin. Your wav files will be moved into a new folder a" +
+            this.group_step1 = new System.Windows.Forms.GroupBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.txtSource = new System.Windows.Forms.TextBox();
+            this.btnChooseSource = new System.Windows.Forms.Button();
+            this.group_step4 = new System.Windows.Forms.GroupBox();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.lblStatus = new System.Windows.Forms.Label();
+            this.convertProgress = new System.Windows.Forms.ProgressBar();
+            this.label3 = new System.Windows.Forms.Label();
+            this.btnConvert = new System.Windows.Forms.Button();
+            this.group_step2 = new System.Windows.Forms.GroupBox();
+            this.label4 = new System.Windows.Forms.Label();
+            this.target_label = new System.Windows.Forms.Label();
+            this.txtTarget = new System.Windows.Forms.TextBox();
+            this.btnChooseTarget = new System.Windows.Forms.Button();
+            this.group_step3 = new System.Windows.Forms.GroupBox();
+            this.boolOverride = new System.Windows.Forms.CheckBox();
+            this.boolRecursive = new System.Windows.Forms.CheckBox();
+            this.boolDelete = new System.Windows.Forms.CheckBox();
+            this.label6 = new System.Windows.Forms.Label();
+            this.group_step1.SuspendLayout();
+            this.group_step4.SuspendLayout();
+            this.group_step2.SuspendLayout();
+            this.group_step3.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // group_step1
+            // 
+            this.group_step1.Controls.Add(this.label1);
+            this.group_step1.Controls.Add(this.label2);
+            this.group_step1.Controls.Add(this.txtSource);
+            this.group_step1.Controls.Add(this.btnChooseSource);
+            this.group_step1.Location = new System.Drawing.Point(5, 2);
+            this.group_step1.Name = "group_step1";
+            this.group_step1.Size = new System.Drawing.Size(380, 67);
+            this.group_step1.TabIndex = 5;
+            this.group_step1.TabStop = false;
+            this.group_step1.Text = "Step 1";
+            // 
+            // label1
+            // 
+            this.label1.Location = new System.Drawing.Point(6, 16);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(293, 16);
+            this.label1.TabIndex = 1;
+            this.label1.Text = "Select the target folder to read the wav files";
+            this.label1.Click += new System.EventHandler(this.label1_Click);
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(7, 38);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(44, 13);
+            this.label2.TabIndex = 3;
+            this.label2.Text = "Source:";
+            // 
+            // txtSource
+            // 
+            this.txtSource.Location = new System.Drawing.Point(57, 35);
+            this.txtSource.Name = "txtSource";
+            this.txtSource.Size = new System.Drawing.Size(242, 20);
+            this.txtSource.TabIndex = 0;
+            this.txtSource.Text = "C:\\Users\\gregf\\Downloads\\SFX\\SFX";
+            this.txtSource.TextChanged += new System.EventHandler(this.txtSource_TextChanged);
+            // 
+            // btnChooseSource
+            // 
+            this.btnChooseSource.Location = new System.Drawing.Point(305, 33);
+            this.btnChooseSource.Name = "btnChooseSource";
+            this.btnChooseSource.Size = new System.Drawing.Size(69, 23);
+            this.btnChooseSource.TabIndex = 2;
+            this.btnChooseSource.Text = "Browse";
+            this.btnChooseSource.UseVisualStyleBackColor = true;
+            this.btnChooseSource.Click += new System.EventHandler(this.btnChooseSource_Click);
+            // 
+            // group_step4
+            // 
+            this.group_step4.Controls.Add(this.btnCancel);
+            this.group_step4.Controls.Add(this.lblStatus);
+            this.group_step4.Controls.Add(this.convertProgress);
+            this.group_step4.Controls.Add(this.label3);
+            this.group_step4.Controls.Add(this.btnConvert);
+            this.group_step4.Location = new System.Drawing.Point(5, 234);
+            this.group_step4.Name = "group_step4";
+            this.group_step4.Size = new System.Drawing.Size(380, 83);
+            this.group_step4.TabIndex = 6;
+            this.group_step4.TabStop = false;
+            this.group_step4.Text = "Step 4";
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.Location = new System.Drawing.Point(305, 50);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(69, 23);
+            this.btnCancel.TabIndex = 5;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
+            // lblStatus
+            // 
+            this.lblStatus.AutoSize = true;
+            this.lblStatus.Location = new System.Drawing.Point(22, 55);
+            this.lblStatus.Name = "lblStatus";
+            this.lblStatus.Size = new System.Drawing.Size(50, 13);
+            this.lblStatus.TabIndex = 4;
+            this.lblStatus.Text = "STATUS";
+            this.lblStatus.Click += new System.EventHandler(this.label5_Click_1);
+            // 
+            // convertProgress
+            // 
+            this.convertProgress.Location = new System.Drawing.Point(6, 50);
+            this.convertProgress.Name = "convertProgress";
+            this.convertProgress.Size = new System.Drawing.Size(293, 23);
+            this.convertProgress.TabIndex = 3;
+            this.convertProgress.Visible = false;
+            // 
+            // label3
+            // 
+            this.label3.Location = new System.Drawing.Point(6, 16);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(368, 31);
+            this.label3.TabIndex = 1;
+            this.label3.Text = "Click the button below to begin. Your wav files will be moved into a new folder a" +
     "nd replaced with .ogg files.";
-			// 
-			// btnConvert
-			// 
-			this.btnConvert.Location = new System.Drawing.Point(161, 50);
-			this.btnConvert.Name = "btnConvert";
-			this.btnConvert.Size = new System.Drawing.Size(69, 23);
-			this.btnConvert.TabIndex = 2;
-			this.btnConvert.Text = "Convert";
-			this.btnConvert.UseVisualStyleBackColor = true;
-			this.btnConvert.Click += new System.EventHandler(this.btnConvert_Click);
-			// 
-			// group_step2
-			// 
-			this.group_step2.Controls.Add(this.label4);
-			this.group_step2.Controls.Add(this.target_label);
-			this.group_step2.Controls.Add(this.txtTarget);
-			this.group_step2.Controls.Add(this.btnChooseTarget);
-			this.group_step2.Location = new System.Drawing.Point(5, 75);
-			this.group_step2.Name = "group_step2";
-			this.group_step2.Size = new System.Drawing.Size(380, 65);
-			this.group_step2.TabIndex = 6;
-			this.group_step2.TabStop = false;
-			this.group_step2.Text = "Step 2";
-			this.group_step2.Enter += new System.EventHandler(this.groupBox1_Enter);
-			// 
-			// label4
-			// 
-			this.label4.Location = new System.Drawing.Point(6, 16);
-			this.label4.Name = "label4";
-			this.label4.Size = new System.Drawing.Size(287, 18);
-			this.label4.TabIndex = 1;
-			this.label4.Text = "Select the destination folder to write the ogg files";
-			// 
-			// target_label
-			// 
-			this.target_label.AutoSize = true;
-			this.target_label.Location = new System.Drawing.Point(7, 34);
-			this.target_label.Name = "target_label";
-			this.target_label.Size = new System.Drawing.Size(41, 13);
-			this.target_label.TabIndex = 3;
-			this.target_label.Text = "Target:\r\n";
-			this.target_label.Click += new System.EventHandler(this.label5_Click);
-			// 
-			// txtTarget
-			// 
-			this.txtTarget.Location = new System.Drawing.Point(57, 34);
-			this.txtTarget.Name = "txtTarget";
-			this.txtTarget.Size = new System.Drawing.Size(242, 20);
-			this.txtTarget.TabIndex = 0;
-			this.txtTarget.TextChanged += new System.EventHandler(this.txtTarget_TextChanged);
-			// 
-			// btnChooseTarget
-			// 
-			this.btnChooseTarget.Location = new System.Drawing.Point(305, 31);
-			this.btnChooseTarget.Name = "btnChooseTarget";
-			this.btnChooseTarget.Size = new System.Drawing.Size(69, 23);
-			this.btnChooseTarget.TabIndex = 2;
-			this.btnChooseTarget.Text = "Browse";
-			this.btnChooseTarget.UseVisualStyleBackColor = true;
-			this.btnChooseTarget.Click += new System.EventHandler(this.button1_Click);
-			// 
-			// group_step3
-			// 
-			this.group_step3.Controls.Add(this.boolOverride);
-			this.group_step3.Controls.Add(this.boolRecursive);
-			this.group_step3.Controls.Add(this.boolDelete);
-			this.group_step3.Controls.Add(this.label6);
-			this.group_step3.Location = new System.Drawing.Point(11, 146);
-			this.group_step3.Name = "group_step3";
-			this.group_step3.Size = new System.Drawing.Size(380, 82);
-			this.group_step3.TabIndex = 7;
-			this.group_step3.TabStop = false;
-			this.group_step3.Text = "Step 3";
-			// 
-			// boolOverride
-			// 
-			this.boolOverride.AutoSize = true;
-			this.boolOverride.Location = new System.Drawing.Point(269, 37);
-			this.boolOverride.Name = "boolOverride";
-			this.boolOverride.Size = new System.Drawing.Size(71, 17);
-			this.boolOverride.TabIndex = 4;
-			this.boolOverride.Text = "Overwrite";
-			this.boolOverride.UseVisualStyleBackColor = true;
-			this.boolOverride.CheckedChanged += new System.EventHandler(this.checkBox2_CheckedChanged);
-			// 
-			// boolRecursive
-			// 
-			this.boolRecursive.AutoSize = true;
-			this.boolRecursive.Location = new System.Drawing.Point(145, 37);
-			this.boolRecursive.Name = "boolRecursive";
-			this.boolRecursive.Size = new System.Drawing.Size(79, 17);
-			this.boolRecursive.TabIndex = 3;
-			this.boolRecursive.Text = "SubFolders";
-			this.boolRecursive.UseVisualStyleBackColor = true;
-			// 
-			// boolDelete
-			// 
-			this.boolDelete.AutoSize = true;
-			this.boolDelete.Location = new System.Drawing.Point(9, 37);
-			this.boolDelete.Name = "boolDelete";
-			this.boolDelete.Size = new System.Drawing.Size(95, 17);
-			this.boolDelete.TabIndex = 2;
-			this.boolDelete.Text = "Delete Original";
-			this.boolDelete.UseVisualStyleBackColor = true;
-			this.boolDelete.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged);
-			// 
-			// label6
-			// 
-			this.label6.Location = new System.Drawing.Point(6, 16);
-			this.label6.Name = "label6";
-			this.label6.Size = new System.Drawing.Size(281, 18);
-			this.label6.TabIndex = 1;
-			this.label6.Text = "Select options when you convert";
-			// 
-			// frmMain
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(397, 329);
-			this.Controls.Add(this.group_step3);
-			this.Controls.Add(this.group_step2);
-			this.Controls.Add(this.group_step4);
-			this.Controls.Add(this.group_step1);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-			this.MaximizeBox = false;
-			this.Name = "frmMain";
-			this.Text = "Batch WAV to OGG Converter";
-			this.Load += new System.EventHandler(this.frmMain_Load);
-			this.group_step1.ResumeLayout(false);
-			this.group_step1.PerformLayout();
-			this.group_step4.ResumeLayout(false);
-			this.group_step4.PerformLayout();
-			this.group_step2.ResumeLayout(false);
-			this.group_step2.PerformLayout();
-			this.group_step3.ResumeLayout(false);
-			this.group_step3.PerformLayout();
-			this.ResumeLayout(false);
+            // 
+            // btnConvert
+            // 
+            this.btnConvert.Location = new System.Drawing.Point(161, 50);
+            this.btnConvert.Name = "btnConvert";
+            this.btnConvert.Size = new System.Drawing.Size(69, 23);
+            this.btnConvert.TabIndex = 2;
+            this.btnConvert.Text = "Convert";
+            this.btnConvert.UseVisualStyleBackColor = true;
+            this.btnConvert.Click += new System.EventHandler(this.btnConvert_Click);
+            // 
+            // group_step2
+            // 
+            this.group_step2.Controls.Add(this.label4);
+            this.group_step2.Controls.Add(this.target_label);
+            this.group_step2.Controls.Add(this.txtTarget);
+            this.group_step2.Controls.Add(this.btnChooseTarget);
+            this.group_step2.Location = new System.Drawing.Point(5, 75);
+            this.group_step2.Name = "group_step2";
+            this.group_step2.Size = new System.Drawing.Size(380, 65);
+            this.group_step2.TabIndex = 6;
+            this.group_step2.TabStop = false;
+            this.group_step2.Text = "Step 2";
+            this.group_step2.Enter += new System.EventHandler(this.groupBox1_Enter);
+            // 
+            // label4
+            // 
+            this.label4.Location = new System.Drawing.Point(6, 16);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(287, 18);
+            this.label4.TabIndex = 1;
+            this.label4.Text = "Select the destination folder to write the ogg files";
+            // 
+            // target_label
+            // 
+            this.target_label.AutoSize = true;
+            this.target_label.Location = new System.Drawing.Point(7, 34);
+            this.target_label.Name = "target_label";
+            this.target_label.Size = new System.Drawing.Size(41, 13);
+            this.target_label.TabIndex = 3;
+            this.target_label.Text = "Target:\r\n";
+            this.target_label.Click += new System.EventHandler(this.label5_Click);
+            // 
+            // txtTarget
+            // 
+            this.txtTarget.Location = new System.Drawing.Point(57, 34);
+            this.txtTarget.Name = "txtTarget";
+            this.txtTarget.Size = new System.Drawing.Size(242, 20);
+            this.txtTarget.TabIndex = 0;
+            this.txtTarget.Text = "C:\\Users\\gregf\\temp";
+            this.txtTarget.TextChanged += new System.EventHandler(this.txtTarget_TextChanged);
+            // 
+            // btnChooseTarget
+            // 
+            this.btnChooseTarget.Location = new System.Drawing.Point(305, 31);
+            this.btnChooseTarget.Name = "btnChooseTarget";
+            this.btnChooseTarget.Size = new System.Drawing.Size(69, 23);
+            this.btnChooseTarget.TabIndex = 2;
+            this.btnChooseTarget.Text = "Browse";
+            this.btnChooseTarget.UseVisualStyleBackColor = true;
+            this.btnChooseTarget.Click += new System.EventHandler(this.btnChooseTarget_Click);
+            // 
+            // group_step3
+            // 
+            this.group_step3.Controls.Add(this.boolOverride);
+            this.group_step3.Controls.Add(this.boolRecursive);
+            this.group_step3.Controls.Add(this.boolDelete);
+            this.group_step3.Controls.Add(this.label6);
+            this.group_step3.Location = new System.Drawing.Point(11, 146);
+            this.group_step3.Name = "group_step3";
+            this.group_step3.Size = new System.Drawing.Size(380, 82);
+            this.group_step3.TabIndex = 7;
+            this.group_step3.TabStop = false;
+            this.group_step3.Text = "Step 3";
+            // 
+            // boolOverride
+            // 
+            this.boolOverride.AutoSize = true;
+            this.boolOverride.Location = new System.Drawing.Point(269, 37);
+            this.boolOverride.Name = "boolOverride";
+            this.boolOverride.Size = new System.Drawing.Size(71, 17);
+            this.boolOverride.TabIndex = 4;
+            this.boolOverride.Text = "Overwrite";
+            this.boolOverride.UseVisualStyleBackColor = true;
+            this.boolOverride.CheckedChanged += new System.EventHandler(this.checkBox2_CheckedChanged);
+            // 
+            // boolRecursive
+            // 
+            this.boolRecursive.AutoSize = true;
+            this.boolRecursive.Location = new System.Drawing.Point(145, 37);
+            this.boolRecursive.Name = "boolRecursive";
+            this.boolRecursive.Size = new System.Drawing.Size(79, 17);
+            this.boolRecursive.TabIndex = 3;
+            this.boolRecursive.Text = "SubFolders";
+            this.boolRecursive.UseVisualStyleBackColor = true;
+            // 
+            // boolDelete
+            // 
+            this.boolDelete.AutoSize = true;
+            this.boolDelete.Location = new System.Drawing.Point(9, 37);
+            this.boolDelete.Name = "boolDelete";
+            this.boolDelete.Size = new System.Drawing.Size(95, 17);
+            this.boolDelete.TabIndex = 2;
+            this.boolDelete.Text = "Delete Original";
+            this.boolDelete.UseVisualStyleBackColor = true;
+            this.boolDelete.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged);
+            // 
+            // label6
+            // 
+            this.label6.Location = new System.Drawing.Point(6, 16);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(281, 18);
+            this.label6.TabIndex = 1;
+            this.label6.Text = "Select options when you convert";
+            // 
+            // frmMain
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(397, 329);
+            this.Controls.Add(this.group_step3);
+            this.Controls.Add(this.group_step2);
+            this.Controls.Add(this.group_step4);
+            this.Controls.Add(this.group_step1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.MaximizeBox = false;
+            this.Name = "frmMain";
+            this.Text = "Batch WAV to OGG Converter";
+            this.Load += new System.EventHandler(this.frmMain_Load);
+            this.group_step1.ResumeLayout(false);
+            this.group_step1.PerformLayout();
+            this.group_step4.ResumeLayout(false);
+            this.group_step4.PerformLayout();
+            this.group_step2.ResumeLayout(false);
+            this.group_step2.PerformLayout();
+            this.group_step3.ResumeLayout(false);
+            this.group_step3.PerformLayout();
+            this.ResumeLayout(false);
 
         }
 

--- a/Batch WAV to OGG Converter/frmMain.cs
+++ b/Batch WAV to OGG Converter/frmMain.cs
@@ -4,352 +4,458 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace Batch_WAV_to_OGG_Converter
 {
-	public partial class frmMain : Form
-	{
-		private List<string> filenames;
-		private int currentFile;
-		private bool isManualOverride = false;
-		private bool isCanceled = false;
-		private bool isProtected = false;
-		private Process process;
+    public partial class frmMain : Form
+    {
+        private List<string> filenames;
+        private int currentFile;
+        private bool isManualOverride = false;
+        private bool isCanceled = false;
+        private bool isProtected = false;
+        private static Process process = null;
 
-		public frmMain()
-		{
-			InitializeComponent();
-		}
+        public frmMain()
+        {
+            InitializeComponent();
+        }
 
-		private void btnChooseSource_Click(object sender, EventArgs e)
-		{
-			using (FolderBrowserDialog fbd = new FolderBrowserDialog())
-			{
-				if (fbd.ShowDialog() == DialogResult.OK)
-				{
-					txtSource.Text = fbd.SelectedPath;
-				}
-			}
-		}
+        private void btnChooseSource_Click(object sender, EventArgs e)
+        {
+            Debug.WriteLine("GLF: btnChooseSource_Click");
+            using (FolderBrowserDialog fbd = new FolderBrowserDialog())
+            {
+                if (fbd.ShowDialog() == DialogResult.OK)
+                {
+                    txtSource.Text = fbd.SelectedPath;
+                }
+            }
+        }
 
-		private void btnChooseTarget_Click(object sender, EventArgs e)
-		{
-			using (FolderBrowserDialog fbd = new FolderBrowserDialog())
-			{
-				if (fbd.ShowDialog() == DialogResult.OK)
-				{
-					txtTarget.Text = fbd.SelectedPath;
-				}
-			}
-		}
+        private void btnChooseTarget_Click(object sender, EventArgs e)
+        {
+            using (FolderBrowserDialog fbd = new FolderBrowserDialog())
+            {
+                if (fbd.ShowDialog() == DialogResult.OK)
+                {
+                    txtTarget.Text = fbd.SelectedPath;
+                }
+            }
+        }
 
-		private void btnCancel_Click(object sender, EventArgs e)
-		{
-			if (process != null && !process.HasExited)
-			{
-				process.Kill();
-			}
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            if (process != null)
+            {
+                try
+                {
+                    if (!process.HasExited)
+                    {
+                        process.Kill();
+                    }
+                }
+                catch (InvalidOperationException ex)
+                {
+                    // Handle the exception, e.g., log it or show a message to the user
+                    Console.WriteLine("Process is not in a valid state: " + ex.Message);
+                }
+            }
+            isCanceled = true;
+            lblStatus.Text = "Stopped";
+            convertProgress.Value = 0;
 
-			isCanceled = true;
-			lblStatus.Text = "Stopped";
-			convertProgress.Value = 0;
+            if (btnCancel.Text == "Reset")
+            {
+                ResetUI();
+            }
+        }
 
-			if (btnCancel.Text == "Reset")
-			{
-				ResetUI();
-			}
-		}
+        private void btnConvert_Click(object sender, EventArgs e)
+        {
+            isCanceled = false;
+            currentFile = 0;
+            ToggleUIForConversion(false);
 
-		private void btnConvert_Click(object sender, EventArgs e)
-		{
-			isCanceled = false;
-			currentFile = 0;
-			ToggleUIForConversion(false);
+            filenames = boolRecursive.Checked
+                ? Directory.GetFiles(txtSource.Text, "*.wav", SearchOption.AllDirectories).ToList()
+                : Directory.GetFiles(txtSource.Text, "*.wav", SearchOption.TopDirectoryOnly).ToList();
 
-			filenames = boolRecursive.Checked
-				? Directory.GetFiles(txtSource.Text, "*.wav", SearchOption.AllDirectories).ToList()
-				: Directory.GetFiles(txtSource.Text, "*.wav", SearchOption.TopDirectoryOnly).ToList();
+            Debug.WriteLine("Files to convert: ");
+            Debug.WriteLine(string.Join("\n", filenames));
+            Debug.WriteLine("--------------------");
 
-			ConvertFile();
-		}
+            ConvertFile();
+        }
 
-		private void ConvertFile()
-		{
-			if (isCanceled || currentFile >= filenames.Count)
-			{
-				FinalizeConversion();
-				return;
-			}
+        private void ConvertFile()
+        {
+            if (isCanceled || currentFile >= filenames.Count)
+            {
+                FinalizeConversion();
+                return;
+            }
 
-			string sourceFilePath = filenames[currentFile];
-			string relativePath = GetRelativePath(txtSource.Text, sourceFilePath);
-			string truncatedRelativePath = TrimRelativePath(relativePath);
+            string sourceFilePath = filenames[currentFile];
+            string relativePath = GetRelativePath(txtSource.Text, sourceFilePath);
+            string truncatedRelativePath = TrimRelativePath(relativePath);
 
-			string targetFilePath = Path.Combine(txtTarget.Text, truncatedRelativePath);
-			string outputFilePath = PrepareTargetDirectory(targetFilePath);
+            string targetFilePath = Path.Combine(txtTarget.Text, truncatedRelativePath);
+            string outputFilePath = PrepareTargetDirectory(targetFilePath);
 
-			lblStatus.Text = $"Processing {truncatedRelativePath}...";
+            SetStatusLabel($"Processing {truncatedRelativePath}...");
 
-			if (File.Exists(outputFilePath) && !boolOverride.Checked)
-			{
-				currentFile++;
-				ConvertFile();
-				return;
-			}
+            Debug.WriteLine("GLF: ConvertFile doing: " + sourceFilePath);
+            if (File.Exists(outputFilePath) && !boolOverride.Checked)
+            {
+                Debug.WriteLine("GLF: SKIPPING: " + sourceFilePath);
+                currentFile++;
+                ConvertFile();
+                return;
+            }
 
-			StartConversionProcess(sourceFilePath, outputFilePath);
-		}
+            StartConversionProcess(sourceFilePath, outputFilePath);
+        }
 
-		private void StartConversionProcess(string sourceFilePath, string outputFilePath)
-		{
-			process = new Process
-			{
-				StartInfo = new ProcessStartInfo
-				{
-					FileName = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), @"ffmpeg\ffmpeg.exe"),
-					Arguments = $"-i \"{sourceFilePath}\" -acodec libvorbis -f ogg \"{outputFilePath}\"",
-					UseShellExecute = false,
-					CreateNoWindow = true
-				}
-			};
 
-			process.Start();
+        // ----------------------------------------------------------------------------------------
+        // Functions to allow other processes to post updates to UI values/text/show&hide, etc.
+        //
 
-			while (!process.HasExited)
-			{
-				if (isCanceled)
-				{
-					process.Kill();
-					DeleteFileIfExists(outputFilePath);
+        delegate void SetButtonCancelTextCallback(string newText, bool doShow);
+        private void SetButtonCancelText(string newText, bool doShow)
+        {
+            if (this.convertProgress.InvokeRequired)
+            {
+                SetButtonCancelTextCallback d = new SetButtonCancelTextCallback(SetButtonCancelText);
+                this.Invoke(d, new object[] { newText, doShow });
+            }
+            else
+            {
+                this.btnCancel.Text = newText;
+                if (doShow)
+                {
+                    this.btnCancel.Show();
+                }
+                else
+                {
+                    this.btnCancel.Hide();
+                }
+            }
+        }
 
-					lblStatus.Text = "Canceled";
-					FinalizeConversion();
-					return;
-				}
 
-				System.Threading.Thread.Sleep(10);
-				Application.DoEvents();
-			}
+        delegate void SetStatusLabelCallback(string statusText);
+        private void SetStatusLabel(string statusText)
+        {
+            if (this.convertProgress.InvokeRequired)
+            {
+                SetStatusLabelCallback d = new SetStatusLabelCallback(SetStatusLabel);
+                this.Invoke(d, new object[] { statusText });
+            }
+            else
+            {
+                this.lblStatus.Text = statusText;
+            }
+        }
 
-			currentFile++;
-			convertProgress.Value = (int)((double)currentFile / filenames.Count * 100.0);
-			ConvertFile();
-		}
 
-		private void FinalizeConversion()
-		{
-			convertProgress.Value = 100;
-			lblStatus.Text = "Conversion Complete";
+        delegate void SetProgressLabelCallback(int newValue);
 
-			if (boolDelete.Checked)
-			{
-				lblStatus.Text = "Deleting old WAV files...";
-				filenames.ForEach(file => RetryDeleteFile(GetRelativePath(txtSource.Text, file)));
-			}
+        private void SetProgressLabel(int newValue)
+        {
+            if (this.convertProgress.InvokeRequired)
+            {
+                SetProgressLabelCallback d = new SetProgressLabelCallback(SetProgressLabel);
+                this.Invoke(d, new object[] { newValue });
+            }
+            else
+            {
+                this.convertProgress.Value = newValue;
+            }
+        }
 
-			isProtected = false;
-			btnCancel.Text = "Reset";
-			btnCancel.Show();
-		}
+        //
+        //
+        // ----------------------------------------------------------------------------------------
 
-		private void frmMain_Load(object sender, EventArgs e)
-		{
-			lblStatus.Text = "Idle";
-			btnCancel.Hide();
+        Task<int> StartConversionProcess(string sourceFilePath, string outputFilePath)
+        {
+            Debug.WriteLine("GLF: StartConversionProcess for: " + sourceFilePath);
 
-			txtSource.TextChanged += txtSource_TextChanged;
-			txtTarget.TextChanged += txtTarget_TextChanged;
+            var tsc = new TaskCompletionSource<int>();
 
-			btnCancel.Click += btnCancel_Click;
-		}
+            process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), @"ffmpeg\ffmpeg.exe"),
+                    Arguments = $"-i \"{sourceFilePath}\" -acodec libvorbis -y -f ogg \"{outputFilePath}\"",
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                },
+                EnableRaisingEvents = true
+            };
 
-		private void txtSource_TextChanged(object sender, EventArgs e) => ValidateSourcePath();
+            process.Exited += (sender, args) =>
+            {
+                Debug.WriteLine("ffmpeg process is exited");
+                tsc.SetResult(process.ExitCode);
+                process.Close();
 
-		private void txtTarget_TextChanged(object sender, EventArgs e) => ValidateTargetPath();
+                if (isCanceled)
+                {
+                    DeleteFileIfExists(outputFilePath);
+                    SetStatusLabel("Canceled");
+                    FinalizeConversion();
+                    return;
+                }
 
-		private void ValidateSourcePath()
-		{
-			if (string.IsNullOrWhiteSpace(txtSource.Text) || !Directory.Exists(txtSource.Text))
-			{
-				group_step4.Hide();
-				return;
-			}
+                currentFile++;
+                SetProgressLabel((int)((double)currentFile / filenames.Count * 100.0));
+                ConvertFile();
+            };
 
-			CheckIfStep4ShouldBeShown();
-		}
+            process.Start();
 
-		private void ValidateTargetPath()
-		{
-			if (string.IsNullOrWhiteSpace(txtTarget.Text) || !Directory.Exists(txtTarget.Text))
-			{
-				group_step4.Hide();
-				return;
-			}
+            return tsc.Task;
+        }
 
-			CheckIfStep4ShouldBeShown();
-		}
+        private void FinalizeConversion()
+        {
+            SetProgressLabel(100);
+            SetStatusLabel("Conversion Complete");
 
-		private void txtSource_Validating(object sender, CancelEventArgs e)
-		{
-			if (this.ActiveControl == btnChooseSource)
-			{
-				btnChooseSource_Click(btnChooseSource, EventArgs.Empty);
-				return;
-			}
+            if (boolDelete.Checked)
+            {
+                SetStatusLabel("Deleting old WAV files...");
+                filenames.ForEach(file =>
+                {
+                    var relFile = GetRelativePath(txtSource.Text, file);
+                    Debug.WriteLine("GLF: FinalizeConversion() relFile: " + relFile);
 
-			ValidatePath(e, txtSource, "The source directory does not exist. Please enter a valid directory.");
-		}
+                    RetryDeleteFile(relFile);
+                });
+                SetStatusLabel("Converted " + filenames.Count + " files successfully.");
+            }
 
-		private void txtTarget_Validating(object sender, CancelEventArgs e)
-		{
-			if (this.ActiveControl == btnChooseTarget)
-			{
-				btnChooseTarget_Click(btnChooseTarget, EventArgs.Empty);
-				return;
-			}
+            isProtected = false;
+            SetButtonCancelText("Reset", true);
+        }
 
-			ValidatePath(e, txtTarget, "The target directory does not exist. Please enter a valid directory.");
-		}
+        private void frmMain_Load(object sender, EventArgs e)
+        {
+            SetStatusLabel("Idle");
+            btnCancel.Hide();
 
-		private void CheckIfStep4ShouldBeShown()
-		{
-			if (Directory.Exists(txtSource.Text) && Directory.Exists(txtTarget.Text))
-			{
-				if (string.Equals(txtSource.Text.Trim(), txtTarget.Text.Trim(), StringComparison.OrdinalIgnoreCase))
-				{
-					MessageBox.Show("Source and Target folders cannot be the same. Please select a different target folder.", "Invalid Folders", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-					group_step4.Hide();
-				}
-				else
-				{
-					group_step4.Show();
-				}
-			}
-			else
-			{
-				group_step4.Hide();
-			}
-		}
+            txtSource.TextChanged += txtSource_TextChanged;
+            txtTarget.TextChanged += txtTarget_TextChanged;
 
-		private string GetRelativePath(string fromPath, string toPath)
-		{
-			Uri fromUri = new Uri(fromPath);
-			Uri toUri = new Uri(toPath);
+            btnCancel.Click += btnCancel_Click;
+        }
 
-			if (fromUri.Scheme != toUri.Scheme) { return toPath; }
+        private void txtSource_TextChanged(object sender, EventArgs e) => ValidateSourcePath();
 
-			Uri relativeUri = fromUri.MakeRelativeUri(toUri);
-			string relativePath = Uri.UnescapeDataString(relativeUri.ToString());
+        private void txtTarget_TextChanged(object sender, EventArgs e) => ValidateTargetPath();
 
-			return toUri.Scheme.Equals("file", StringComparison.InvariantCultureIgnoreCase)
-				? relativePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)
-				: relativePath;
-		}
+        private void ValidateSourcePath()
+        {
+            if (string.IsNullOrWhiteSpace(txtSource.Text) || !Directory.Exists(txtSource.Text))
+            {
+                group_step4.Hide();
+                return;
+            }
 
-		private string TrimRelativePath(string relativePath)
-		{
-			if (relativePath.StartsWith(Path.GetFileName(txtSource.Text) + Path.DirectorySeparatorChar))
-			{
-				return relativePath.Substring(Path.GetFileName(txtSource.Text).Length + 1);
-			}
+            CheckIfStep4ShouldBeShown();
+        }
 
-			return relativePath;
-		}
+        private void ValidateTargetPath()
+        {
+            if (string.IsNullOrWhiteSpace(txtTarget.Text) || !Directory.Exists(txtTarget.Text))
+            {
+                group_step4.Hide();
+                return;
+            }
 
-		private string PrepareTargetDirectory(string targetFilePath)
-		{
-			string targetDirectory = Path.GetDirectoryName(targetFilePath);
+            CheckIfStep4ShouldBeShown();
+        }
 
-			if (!Directory.Exists(targetDirectory))
-			{
-				Directory.CreateDirectory(targetDirectory);
-			}
+        private void txtSource_Validating(object sender, CancelEventArgs e)
+        {
+            if (this.ActiveControl == btnChooseSource)
+            {
+                btnChooseSource_Click(btnChooseSource, EventArgs.Empty);
+                return;
+            }
 
-			return Path.ChangeExtension(targetFilePath, ".ogg");
-		}
+            ValidatePath(e, txtSource, "The source directory does not exist. Please enter a valid directory.");
+        }
 
-		private bool RetryDeleteFile(string relativeFilePath)
-		{
-			int retryCount = 0;
-			const int maxRetry = 10;
-			string filePath = Path.Combine(txtSource.Text, relativeFilePath);
+        private void txtTarget_Validating(object sender, CancelEventArgs e)
+        {
+            if (this.ActiveControl == btnChooseTarget)
+            {
+                btnChooseTarget_Click(btnChooseTarget, EventArgs.Empty);
+                return;
+            }
 
-			while (retryCount < maxRetry)
-			{
-				if (TryDeleteFile(filePath)) return true;
+            ValidatePath(e, txtTarget, "The target directory does not exist. Please enter a valid directory.");
+        }
 
-				retryCount++;
-				System.Threading.Thread.Sleep(retryCount * 2000);
-			}
+        private void CheckIfStep4ShouldBeShown()
+        {
+            if (Directory.Exists(txtSource.Text) && Directory.Exists(txtTarget.Text))
+            {
+                if (string.Equals(txtSource.Text.Trim(), txtTarget.Text.Trim(), StringComparison.OrdinalIgnoreCase))
+                {
+                    MessageBox.Show("Source and Target folders cannot be the same. Please select a different target folder.", "Invalid Folders", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    group_step4.Hide();
+                }
+                else
+                {
+                    group_step4.Show();
+                }
+            }
+            else
+            {
+                group_step4.Hide();
+            }
+        }
 
-			isProtected = true;
-			return false;
-		}
+        private string GetRelativePath(string fromPath, string toPath)
+        {
+            Uri fromUri = new Uri(fromPath);
+            Uri toUri = new Uri(toPath);
 
-		private bool TryDeleteFile(string filePath)
-		{
-			try
-			{
-				if (File.Exists(filePath))
-				{
-					File.Delete(filePath);
-					return true;
-				}
-			}
-			catch (IOException) { }
+            if (fromUri.Scheme != toUri.Scheme) { return toPath; }
 
-			return false;
-		}
+            string fromStr = fromUri.ToString();
+            string toStr = toUri.ToString();
 
-		private void DeleteFileIfExists(string outputFilePath)
-		{
-			if (File.Exists(outputFilePath))
-			{
-				File.Delete(outputFilePath);
-			}
-		}
+            string diffStr = toStr.Substring(fromStr.Length+1);
 
-		private void ValidatePath(CancelEventArgs e, TextBox textBox, string errorMessage)
-		{
-			if (string.IsNullOrWhiteSpace(textBox.Text) || !Directory.Exists(textBox.Text))
-			{
-				MessageBox.Show(errorMessage);
-				e.Cancel = true;
-				textBox.Focus();
-			}
-		}
+            return diffStr;
+        }
 
-		private void ToggleUIForConversion(bool enable)
-		{
-			btnChooseSource.Enabled = enable;
-			btnChooseTarget.Enabled = enable;
-			boolDelete.Enabled = enable;
-			boolRecursive.Enabled = enable;
-			boolOverride.Enabled = enable;
-			txtSource.ReadOnly = !enable;
-			txtTarget.ReadOnly = !enable;
-			btnConvert.Visible = enable;
-			btnCancel.Visible = !enable;
-			convertProgress.Visible = !enable;
-		}
+        private string TrimRelativePath(string relativePath)
+        {
+            if (relativePath.StartsWith(Path.GetFileName(txtSource.Text) + Path.DirectorySeparatorChar))
+            {
+                return relativePath.Substring(Path.GetFileName(txtSource.Text).Length + 1);
+            }
 
-		private void ResetUI()
-		{
-			btnCancel.Hide();
-			btnConvert.Show();
-			convertProgress.Hide();
-			ToggleUIForConversion(true);
-			lblStatus.Text = "Idle";
-		}
+            return relativePath;
+        }
 
-		// Empty functions required for assembly
-		private void groupBox1_Enter(object sender, EventArgs e) { }
-		private void label5_Click(object sender, EventArgs e) { }
-		private void label1_Click(object sender, EventArgs e) { }
-		private void checkBox1_CheckedChanged(object sender, EventArgs e) { }
-		private void button1_Click(object sender, EventArgs e) { }
-		private void label5_Click_1(object sender, EventArgs e) { }
-		private void checkBox2_CheckedChanged(object sender, EventArgs e) { }
-	}
+        private string PrepareTargetDirectory(string targetFilePath)
+        {
+            string targetDirectory = Path.GetDirectoryName(targetFilePath);
+
+            if (!Directory.Exists(targetDirectory))
+            {
+                Directory.CreateDirectory(targetDirectory);
+            }
+
+            return Path.ChangeExtension(targetFilePath, ".ogg");
+        }
+
+        private bool RetryDeleteFile(string relativeFilePath)
+        {
+            int retryCount = 0;
+            const int maxRetry = 10;
+            string filePath = Path.Combine(txtSource.Text, relativeFilePath);
+
+            while (retryCount < maxRetry)
+            {
+                Debug.WriteLine("GLF: deleting file try #(" + (retryCount + 1) + "): " + filePath);
+
+                if (TryDeleteFile(filePath)) return true;
+
+                retryCount++;
+                // System.Threading.Thread.Sleep(retryCount * 2000);
+            }
+
+            isProtected = true;
+            return false;
+        }
+
+        private bool TryDeleteFile(string filePath)
+        {
+            try
+            {
+                Debug.WriteLine("GLF: TryDeleteFile() - file exists");
+                if (File.Exists(filePath))
+                {
+                    Debug.WriteLine("GLF: TryDeleteFile() - file exists");
+                    System.GC.Collect();
+                    System.GC.WaitForPendingFinalizers();
+                    File.Delete(filePath);
+                    return true;
+                }
+                else
+                {
+                    Debug.WriteLine("GLF: TryDeleteFile() - file does NOT exist: " + filePath);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine("GLF: caught when deleting file:\n\n" + ex.ToString());
+            }
+
+            return false;
+        }
+
+        private void DeleteFileIfExists(string outputFilePath)
+        {
+            if (File.Exists(outputFilePath))
+            {
+                File.Delete(outputFilePath);
+            }
+        }
+
+        private void ValidatePath(CancelEventArgs e, TextBox textBox, string errorMessage)
+        {
+            if (string.IsNullOrWhiteSpace(textBox.Text) || !Directory.Exists(textBox.Text))
+            {
+                MessageBox.Show(errorMessage);
+                e.Cancel = true;
+                textBox.Focus();
+            }
+        }
+
+        private void ToggleUIForConversion(bool enable)
+        {
+            btnChooseSource.Enabled = enable;
+            btnChooseTarget.Enabled = enable;
+            boolDelete.Enabled = enable;
+            boolRecursive.Enabled = enable;
+            boolOverride.Enabled = enable;
+            txtSource.ReadOnly = !enable;
+            txtTarget.ReadOnly = !enable;
+            btnConvert.Visible = enable;
+            btnCancel.Visible = !enable;
+            convertProgress.Visible = !enable;
+        }
+
+        private void ResetUI()
+        {
+            btnCancel.Hide();
+            btnConvert.Show();
+            convertProgress.Hide();
+            ToggleUIForConversion(true);
+            lblStatus.Text = "Idle";
+        }
+
+        // Empty functions required for assembly
+        private void groupBox1_Enter(object sender, EventArgs e) { }
+        private void label5_Click(object sender, EventArgs e) { }
+        private void label1_Click(object sender, EventArgs e) { }
+        private void checkBox1_CheckedChanged(object sender, EventArgs e) { }
+        private void button1_Click(object sender, EventArgs e) { }
+        private void label5_Click_1(object sender, EventArgs e) { }
+        private void checkBox2_CheckedChanged(object sender, EventArgs e) { }
+
+    }
 }


### PR DESCRIPTION
- updating UI elements from asynchronous processes (threads)
- force overwrite of existing files (add "-y" arg to ffmpeg)
- use a Task for handling process launching and cleanup
- ensure process releases its resources with process.Close()
- remove "busy wait" of main UI thread
- relative path calculations are now correct